### PR TITLE
Change default branch for iceoryx to 'main'

### DIFF
--- a/otterdog/eclipse-iceoryx.jsonnet
+++ b/otterdog/eclipse-iceoryx.jsonnet
@@ -24,7 +24,6 @@ orgs.newOrg('eclipse-iceoryx') {
     orgs.newRepo('iceoryx') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      default_branch: "master",
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       description: "Eclipse iceoryx™ - true zero-copy inter-process-communication",
@@ -71,7 +70,7 @@ orgs.newOrg('eclipse-iceoryx') {
         },
       ],
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('[master][release_]*') {
+        orgs.newBranchProtectionRule('[main][release_]*') {
           dismisses_stale_reviews: true,
           required_approving_review_count: 1,
           requires_status_checks: false,


### PR DESCRIPTION
This PR changes the default branch on iceoryx to `main`, which harmonizes the default branches of all eclipse-iceoryx repos