### PR TITLE
Rename meta-yocto-iceoryx2 repository to meta-iceoryx2

### DIFF
--- a/otterdog/eclipse-iceoryx.jsonnet
+++ b/otterdog/eclipse-iceoryx.jsonnet
@@ -209,7 +209,8 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         },
       ],
     },
-    orgs.newRepo('meta-yocto-iceoryx2') {
+    orgs.newRepo('meta-iceoryx2') {
+      aliases: ['meta-yocto-iceoryx2'],
       allow_merge_commit: true,
       allow_update_branch: false,
       dependabot_security_updates_enabled: true,


### PR DESCRIPTION
This PR renames the `meta-yocto-iceoryx2` repo to `meta-iceoryx2` to be more in line with the convention of the Yocto community.