### PR TITLE
Use a sync point for aggregating all status checks in iceoryx2

### DIFF
--- a/otterdog/eclipse-iceoryx.jsonnet
+++ b/otterdog/eclipse-iceoryx.jsonnet
@@ -226,14 +226,14 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="main", approver_count=1) {
           required_status_checks+: {
             status_checks+: [
-              "x86_64"
+              "mandatory-checks"
             ],
           },
         },
         custom_branch_protection_rule(branch_pattern="release_*", approver_count=1) {
           required_status_checks+: {
             status_checks+: [
-              "x86_64"
+              "mandatory-checks"
             ],
           },
         },


### PR DESCRIPTION
To avoid that we need to list multiple CI jobs from iceoryx2 here we introduce in iceoryx2 repo a central sync point in CI that collects all jobs that need to pass for a Pull-Request merge.

This needs to be merged first and after that PR https://github.com/eclipse-iceoryx/iceoryx2/pull/1052.
See Commit: https://github.com/eclipse-iceoryx/iceoryx2/pull/1052/commits/a9f9675d4a3387a74e8c426a61a8e382bacf4539

Mandatory review from @elBoberido needed before merging here. 
