### PR TITLE
Disable strict enforcing of status-checks

### DIFF
--- a/otterdog/eclipse-iceoryx.jsonnet
+++ b/otterdog/eclipse-iceoryx.jsonnet
@@ -10,7 +10,7 @@ local custom_branch_protection_rule(branch_pattern, approver_count) =
       required_approving_review_count: approver_count,
     },
     required_status_checks+: {
-      strict: true,
+      strict: false,
     }
   };
 


### PR DESCRIPTION
By disabling this we do not enforce that changes in a Pull Request must have been tested with the latest main before merging. The rest of the required status checks still apply. See https://otterdog.readthedocs.io/en/stable/reference/organization/ruleset/#status-check-settings