### PR TITLE
Enable private vulnerability reporting

### DIFF
--- a/otterdog/eclipse-iceoryx.jsonnet
+++ b/otterdog/eclipse-iceoryx.jsonnet
@@ -323,7 +323,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
       allow_merge_commit: true,
       allow_update_branch: false,
       dependabot_security_updates_enabled: true,
-      description: "C-Sharp Language Binding for iceoryx2™",
+      description: "C-Sharp Language Binding for Eclipse iceoryx2™",
       has_discussions: true,
       homepage: "https://iceoryx.io",
       topics+: [

--- a/otterdog/eclipse-iceoryx.jsonnet
+++ b/otterdog/eclipse-iceoryx.jsonnet
@@ -35,6 +35,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="main", approver_count=1) {
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx') {
       allow_merge_commit: true,
@@ -103,6 +104,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
           value: "pass:bots/technology.iceoryx/codecov.io/iceoryx-upload-token",
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx-automotive-soa') {
       allow_merge_commit: true,
@@ -126,6 +128,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="release_*", approver_count=1) {
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx-gateway-dds') {
       allow_merge_commit: true,
@@ -141,6 +144,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="release_*", approver_count=1) {
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx-project-template') {
       allow_merge_commit: true,
@@ -154,6 +158,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="main", approver_count=1) {
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx-rs') {
       allow_squash_merge: false,
@@ -174,6 +179,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
           value: "pass:bots/technology.iceoryx/codecov.io/iceoryx-rs-upload-token",
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx-web') {
       allow_merge_commit: true,
@@ -194,6 +200,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="main", approver_count=1) {
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx2') {
       allow_merge_commit: true,
@@ -268,6 +275,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
           value: "pass:bots/technology.iceoryx/codecov.io/iceoryx2-upload-token",
         },
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('meta-iceoryx2') {
       aliases: ['meta-yocto-iceoryx2'],
@@ -309,6 +317,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="main", approver_count=1),
         custom_branch_protection_rule(branch_pattern="release_*", approver_count=1),
       ],
+      private_vulnerability_reporting_enabled: true,
     },
     orgs.newRepo('iceoryx2-csharp') {
       allow_merge_commit: true,
@@ -350,6 +359,7 @@ orgs.newOrg('technology.iceoryx', 'eclipse-iceoryx') {
         custom_branch_protection_rule(branch_pattern="main", approver_count=1),
         custom_branch_protection_rule(branch_pattern="release_*", approver_count=1),
       ],
+      private_vulnerability_reporting_enabled: true,
     },
   ],
 }


### PR DESCRIPTION
To enable security researchers a way to report security issues privately we should enable the GitHub feature for it in all repositories.

Information: https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository
